### PR TITLE
Builtins naked

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
         with:
           target: thumbv6m-none-eabi
       - name: Install cargo-hack
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
         with:
           target: thumbv6m-none-eabi
       - name: Install cargo-hack
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
         with:
           target: thumbv6m-none-eabi
       - name: Install cargo-hack
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
         with:
           target: thumbv6m-none-eabi
       - name: Build on-target-tests

--- a/rp2040-hal/src/sio.rs
+++ b/rp2040-hal/src/sio.rs
@@ -208,73 +208,40 @@ impl SioFifo {
 // alias the division operators to these for a similar reason r0 is the
 // result either way and r1 a scratch register, so the caller can't assume it
 // retains the argument value.
-#[cfg(target_arch = "arm")]
-core::arch::global_asm!(
-    ".macro hwdivider_head",
-    "ldr    r2, =(0xd0000000)", // SIO_BASE
-    // Check the DIRTY state of the divider by shifting it into the C
-    // status bit.
-    "ldr    r3, [r2, #0x078]", // DIV_CSR
-    "lsrs   r3, #2",           // DIRTY = 1, so shift 2 down
-    // We only need to save the state when DIRTY, otherwise we can just do the
-    // division directly.
-    "bcs    2f",
-    "1:",
-    // Do the actual division now, we're either not DIRTY, or we've saved the
-    // state and branched back here so it's safe now.
-    ".endm",
-    ".macro hwdivider_tail",
-    // 8 cycle delay to wait for the result.  Each branch takes two cycles
-    // and fits into a 2-byte Thumb instruction, so this is smaller than
-    // 8 NOPs.
-    "b      3f",
-    "3: b   3f",
-    "3: b   3f",
-    "3: b   3f",
-    "3:",
-    // Read the quotient last, since that's what clears the dirty flag.
-    "ldr    r1, [r2, #0x074]", // DIV_REMAINDER
-    "ldr    r0, [r2, #0x070]", // DIV_QUOTIENT
-    // Either return to the caller or back to the state restore.
-    "bx     lr",
-    "2:",
-    // Since we can't save the signed-ness of the calculation, we have to make
-    // sure that there's at least an 8 cycle delay before we read the result.
-    // The push takes 5 cycles, and we've already spent at least 7 checking
-    // the DIRTY state to get here.
-    "push   {{r4-r6, lr}}",
-    // Read the quotient last, since that's what clears the dirty flag.
-    "ldr    r3, [r2, #0x060]", // DIV_UDIVIDEND
-    "ldr    r4, [r2, #0x064]", // DIV_UDIVISOR
-    "ldr    r5, [r2, #0x074]", // DIV_REMAINDER
-    "ldr    r6, [r2, #0x070]", // DIV_QUOTIENT
-    // If we get interrupted here (before a write sets the DIRTY flag) it's
-    // fine, since we have the full state, so the interruptor doesn't have to
-    // restore it.  Once the write happens and the DIRTY flag is set, the
-    // interruptor becomes responsible for restoring our state.
-    "bl     1b",
-    // If we are interrupted here, then the interruptor will start an incorrect
-    // calculation using a wrong divisor, but we'll restore the divisor and
-    // result ourselves correctly. This sets DIRTY, so any interruptor will
-    // save the state.
-    "str    r3, [r2, #0x060]", // DIV_UDIVIDEND
-    // If we are interrupted here, the the interruptor may start the
-    // calculation using incorrectly signed inputs, but we'll restore the
-    // result ourselves. This sets DIRTY, so any interruptor will save the
-    // state.
-    "str    r4, [r2, #0x064]", // DIV_UDIVISOR
-    // If we are interrupted here, the interruptor will have restored
-    // everything but the quotient may be wrongly signed.  If the calculation
-    // started by the above writes is still ongoing it is stopped, so it won't
-    // replace the result we're restoring.  DIRTY and READY set, but only
-    // DIRTY matters to make the interruptor save the state.
-    "str    r5, [r2, #0x074]", // DIV_REMAINDER
-    // State fully restored after the quotient write.  This sets both DIRTY
-    // and READY, so whatever we may have interrupted can read the result.
-    "str    r6, [r2, #0x070]", // DIV_QUOTIENT
-    "pop    {{r4-r6, pc}}",
-    ".endm",
-);
+macro_rules! hwdivider_head {
+    () => {
+        "ldr    r2, =(0xd0000000)
+        ldr    r3, [r2, #0x078]
+        lsrs   r3, #2
+        bcs    2f
+        1:"
+    }
+}
+
+macro_rules! hwdivider_tail {
+    () => {
+        "b      3f
+        3: b   3f
+        3: b   3f
+        3: b   3f
+        3:
+        ldr    r1, [r2, #0x074]
+        ldr    r0, [r2, #0x070]
+        bx     lr
+        2:
+        push   {{r4-r6, lr}}
+        ldr    r3, [r2, #0x060]
+        ldr    r4, [r2, #0x064]
+        ldr    r5, [r2, #0x074]
+        ldr    r6, [r2, #0x070]
+        bl     1b
+        str    r3, [r2, #0x060]
+        str    r4, [r2, #0x064]
+        str    r5, [r2, #0x074]
+        str    r6, [r2, #0x070]
+        pop    {{r4-r6, pc}}"
+    }
+}
 
 macro_rules! division_function {
     (
@@ -287,18 +254,18 @@ macro_rules! division_function {
             #[naked]
             unsafe extern "C" fn $intrinsic() {
                 core::arch::asm!(
-                    "hwdivider_head",
+                    hwdivider_head!(),
                     $($begin),+ ,
-                    "hwdivider_tail",
+                    hwdivider_tail!(),
                     options(noreturn)
                     );
             }
             #[naked]
             unsafe extern "C" fn $intrinsic_alias() {
                 core::arch::asm!(
-                    "hwdivider_head",
+                    hwdivider_head!(),
                     $($begin),+ ,
-                    "hwdivider_tail",
+                    hwdivider_tail!(),
                     options(noreturn)
                     );
             }
@@ -311,9 +278,9 @@ macro_rules! division_function {
             ".align 2",
             concat!("_rphal_", stringify!($name), ":"),
 
-            "hwdivider_head",
+            hwdivider_head!(),
             $($begin),+ ,
-            "hwdivider_tail",
+            hwdivider_tail!(),
         );
 
         #[cfg(target_arch = "arm")]


### PR DESCRIPTION
A few changes to make it compile.

I didn't have time to test the result yet. And the way I replaced the asm macros is quick-and-dirty, removing all the very useful comments for now. In case we need to do something like this, the comments need to be restored somehow. Probably by using some kind of `concat!` macro to concatenate separate strings instead of providing the asm blocks as single multi-line strings.